### PR TITLE
bool variation fallback and android init changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const user = {
 LaunchDarkly.configure('apiKey', user);
 
 // get boolean feature flag value
-LaunchDarkly.boolVariation('featureFlagName', (showFeature) => {
+LaunchDarkly.boolVariation('featureFlagName', false, (showFeature) => {
   console.log('Show feature:', showFeature);
 });
 

--- a/android/src/main/java/com/reactlibrary/RNLaunchDarklyModule.java
+++ b/android/src/main/java/com/reactlibrary/RNLaunchDarklyModule.java
@@ -110,8 +110,8 @@ public class RNLaunchDarklyModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void boolVariation(String flagName, Callback callback) {
-    Boolean variationResult = ldClient.boolVariation(flagName, false);
+  public void boolVariation(String flagName, Boolean fallback, Callback callback) {
+    Boolean variationResult = ldClient.boolVariation(flagName, fallback);
     callback.invoke(variationResult);
   }
 

--- a/android/src/main/java/com/reactlibrary/RNLaunchDarklyPackage.java
+++ b/android/src/main/java/com/reactlibrary/RNLaunchDarklyPackage.java
@@ -1,6 +1,8 @@
 
 package com.reactlibrary;
 
+import android.app.Application;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -11,9 +13,16 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.bridge.JavaScriptModule;
 public class RNLaunchDarklyPackage implements ReactPackage {
+    private Application application;
+  
+    public RNLaunchDarklyPackage(Application application) {
+      super();
+      this.application = application;
+    }
+
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-      return Arrays.<NativeModule>asList(new RNLaunchDarklyModule(reactContext));
+      return Arrays.<NativeModule>asList(new RNLaunchDarklyModule(this.application, reactContext));
     }
 
     public List<Class<? extends JavaScriptModule>> createJSModules() {

--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ class LaunchDarkly {
     RNLaunchDarkly.configure(apiKey, options);
   }
 
-  boolVariation (featureName, callback) {
-    RNLaunchDarkly.boolVariation(featureName, callback);
+  boolVariation (featureName, fallback, callback) {
+    RNLaunchDarkly.boolVariation(featureName, fallback, callback);
   }
 
   stringVariation (featureName, fallback, callback) {

--- a/ios/RNLaunchDarkly/RNLaunchDarkly.m
+++ b/ios/RNLaunchDarkly/RNLaunchDarkly.m
@@ -61,8 +61,8 @@ RCT_EXPORT_METHOD(configure:(NSString*)apiKey options:(NSDictionary*)options) {
     [[LDClient sharedInstance] start:config userBuilder:user];
 }
 
-RCT_EXPORT_METHOD(boolVariation:(NSString*)flagName callback:(RCTResponseSenderBlock)callback) {
-    BOOL showFeature = [[LDClient sharedInstance] boolVariation:flagName fallback:NO];
+RCT_EXPORT_METHOD(boolVariation:(NSString*)flagName fallback:(BOOL)fallback callback:(RCTResponseSenderBlock)callback) {
+    BOOL showFeature = [[LDClient sharedInstance] boolVariation:flagName fallback:fallback];
     callback(@[[NSNumber numberWithBool:showFeature]]);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launch-darkly-react-native",
-  "version": "0.0.13",
+  "version": "0.0.13-convoy-v1",
   "description": "React Native wrapper over LaunchDarkly SDK's for iOS and Android.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* change `boolVariation()` to take a `fallback` parameter in the JS side (Android and iOS native changes required)
* change `RNLaunchDarklyModule` and `RNLaunchDarklyPackage` on the Android side to take the Android `Application` in the constructor so that it will always be available within `configure()`, which means that `LDClient.init()` can always be called safely.